### PR TITLE
Fix allocation to support longer problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 CC=gcc
 OFLAGS=-O3
-CFLAGS=$(OFLAGS) -std=c99 -Wall -Wno-unused-variable -Wno-unused-function -march=native
+CFLAGS=$(OFLAGS) -std=c99 -Wall -Wno-unused-variable -Wno-unused-function -march=native -g
 
 all: example example.2bit example.protein
 

--- a/dozeu.h
+++ b/dozeu.h
@@ -1059,7 +1059,7 @@ struct dz_s *dz_init_intl(
     size_t self_and_matrix_size = sizeof(struct dz_s);
     #if defined(DZ_NUCL_ASCII) || defined(DZ_NUCL_2BIT)
         #ifdef DZ_QUAL_ADJ
-            self_and_matrix_size += 2 * DZ_QUAL_MATRIX_SIZE);
+            self_and_matrix_size += 2 * DZ_QUAL_MATRIX_SIZE;
         #endif
     #else
             self_and_matrix_size += DZ_MAT_SIZE * DZ_MAT_SIZE + 2 * sizeof(__m128i);

--- a/dozeu.h
+++ b/dozeu.h
@@ -784,8 +784,6 @@ unittest() {
 	slice_data - (_spos); \
 })
 
-#define _unwind_cap(_c)				( dz_ccap(dz_cswgv(_c) - (_c)->r.epos + (_c)->r.spos) - 1 )
-
 /*
  * Fill in a terminating cap for the most recent column passed to _end_column,
  * using the range information in the current active allocation.
@@ -816,7 +814,7 @@ unittest() {
 		dz_mem_stream_reserve(dz_mem(self), next_req_split); \
 		cap = _init_cap(0, _rch, &cap, 1); \
 	} \
-	debug("create column(%p) pcap(%p), [%u, %u), span(%u), rrem(%ld), max(%d), inc(%d)", cap, _unwind_cap(cap), (_w).fr.spos, (_w).fr.epos, (_w).r.epos - (_w).r.spos, (_rlen), (_w).max, (_w).inc); \
+	debug("create column(%p), [%u, %u), span(%u), rrem(%ld), max(%d), inc(%d)", cap, (_w).fr.spos, (_w).fr.epos, (_w).r.epos - (_w).r.spos, (_rlen), (_w).max, (_w).inc); \
 	/* start array slice allocation */ \
 	struct dz_swgv_s *slice_data = dz_swgv(dz_mem_stream_alloc_begin(dz_mem(self), _calc_max_slice_size((_w).fr.spos, (_w).fr.epos))); \
 	/* return array pointer */ \

--- a/dozeu.h
+++ b/dozeu.h
@@ -677,6 +677,7 @@ void *dz_mem_stream_alloc(
 	/* TODO: Optimize instead of using the async primitives. */
 	void *ptr = dz_mem_stream_alloc_begin(mem, size);
 	if(dz_mem_stream_alloc_end(mem, size)) {
+		debug("Stream alloc failed");
 		ptr = NULL;
 	}
 	return ptr;
@@ -700,6 +701,7 @@ void *dz_mem_stream_right_alloc(
 
 	void *ptr = dz_mem_stream_alloc(mem, alloc_size);
 	if(ptr == NULL) {
+		debug("Stream right alloc failed");
 		return ptr;
 	}
 	void* right_aligned_ptr = (void*)((uint8_t*)ptr + (alloc_size - data_size));
@@ -2201,7 +2203,6 @@ uint64_t dz_calc_max_pos(struct dz_forefront_s const *forefront)
 		} \
 		_push_span(dz_cff(pcap)->rid);								/* push segment info */ \
 		_score = _s(_l, pcap, idx); \
-		*drp++ = ':'; *dqp++ = ':'; \
 	} \
 	/* return the reference-side base */ \
 	ref_length++; pcap->rch; \
@@ -2239,9 +2240,6 @@ struct dz_alignment_s *dz_trace(
 	struct dz_cap_s const *pcap = forefront->mcap, *cap = NULL;
 	struct dz_query_s const *query = forefront->query;
 	int32_t score = _s(s, pcap, idx), cnt[4] = { 0 };
-    
-	uint8_t debug_ref[1024], debug_query[1024];
-	uint8_t *drp = debug_ref, *dqp = debug_query;
     
     #ifdef DZ_QUAL_ADJ
     #    define _pair_score(_self, _q, _r, _i)   ( dz_qual_adj_pair_score((_self), (_q), (_r), (_i)) )

--- a/dozeu.h
+++ b/dozeu.h
@@ -601,11 +601,11 @@ unittest() {
 #define _init_cap(_adj, _rch, _forefronts, _n_forefronts) ({ \
 	/* push forefront pointers */ \
 	size_t forefront_arr_size = dz_roundup(sizeof(struct dz_forefront_s *) * (_n_forefronts), sizeof(__m128i)); \
-	struct dz_forefront_s const **dst = (struct dz_forefront_s const **)(dz_mem(self)->stack.top + forefront_arr_size); \
+	struct dz_forefront_s const **dst = ((struct dz_forefront_s const **)(dz_mem(self)->stack.top + forefront_arr_size)) - ((int64_t)(_n_forefronts)); \
 	struct dz_forefront_s const **src = (struct dz_forefront_s const **)(_forefronts); \
-	for(size_t i = 0; i < (_n_forefronts); i++) { dst[-((int64_t)(_n_forefronts)) + i] = src[i]; } \
+	for(size_t i = 0; i < (_n_forefronts); i++) { dst[i] = src[i]; } \
 	/* push head-cap info */ \
-	struct dz_head_s *_head = (struct dz_head_s *)dst; \
+	struct dz_head_s *_head = (struct dz_head_s *)(dst + ((int64_t)(_n_forefronts))); \
 	(_head)->r.spos = (_adj);					/* save merging adjustment */ \
 	(_head)->r.epos = 0;						/* head marked as zero */ \
 	(_head)->rch = (_rch);						/* rch for the first column */ \

--- a/dozeu.h
+++ b/dozeu.h
@@ -1,6 +1,6 @@
 // $(CC) -O3 -march=native -DMAIN -o dozeu dozeu.c
 //#ifdef DZ_QUAL_ADJ
-#define DEBUG
+//#define DEBUG
 //#endif
 //#define DZ_PRINT_VECTOR
 /**
@@ -746,7 +746,7 @@ unittest() {
 
 #define _calc_max_slice_size(_sp, _ep) ({ \
     size_t max_slice_size = (2 * ((_ep) - (_sp)) * sizeof(struct dz_swgv_s)); \
-    debug("sp(%lu), ep(%lu), max_slice_size(%lu)", (size_t) (_sp), (size_t) (_ep), max_slice_size); \
+    /* debug("sp(%lu), ep(%lu), max_slice_size(%lu)", (size_t) (_sp), (size_t) (_ep), max_slice_size); */ \
     max_slice_size; \
 })
 /*
@@ -761,7 +761,7 @@ unittest() {
 	size_t forefront_arr_size = dz_roundup(sizeof(struct dz_forefront_s *) * (_nt), sizeof(__m128i)); \
 	size_t est_column_size = _calc_max_slice_size(_sp, _ep); \
 	size_t next_req = forefront_arr_size + est_column_size + sizeof(struct dz_forefront_s); \
-	debug("sp(%lu), ep(%lu), nt(%lu), est_column_size(%lu), next_req(%lu)", (size_t) (_sp), (size_t) (_ep), (size_t) (_nt), est_column_size, next_req); \
+	/* debug("sp(%lu), ep(%lu), nt(%lu), est_column_size(%lu), next_req(%lu)", (size_t) (_sp), (size_t) (_ep), (size_t) (_nt), est_column_size, next_req); */ \
 	next_req; \
 })
 /*
@@ -773,12 +773,10 @@ unittest() {
 #define _init_cap(_adj, _rch, _forefronts, _n_forefronts) ({ \
 	/* push forefront pointers */ \
 	size_t forefront_arr_size = dz_roundup(sizeof(struct dz_forefront_s *) * (_n_forefronts), sizeof(__m128i)); \
-	debug("Allocate %lu forefronts", ((size_t) (_n_forefronts))); \
     struct dz_forefront_s const **dst = (struct dz_forefront_s const **)(dz_mem_stream_right_alloc(dz_mem(self), (int64_t)(_n_forefronts), sizeof(struct dz_forefront_s *), sizeof(__m128i))); \
 	struct dz_forefront_s const **src = (struct dz_forefront_s const **)(_forefronts); \
 	for(size_t i = 0; i < (_n_forefronts); i++) { dst[i] = src[i]; } \
 	/* push head-cap info */ \
-    debug("Allocate head"); \
 	struct dz_head_s *_head = (struct dz_head_s *)(dz_mem_stream_alloc(dz_mem(self), sizeof(struct dz_head_s))); \
 	(_head)->r.spos = (_adj);					/* save merging adjustment */ \
 	(_head)->r.epos = 0;						/* head marked as zero */ \
@@ -799,7 +797,6 @@ unittest() {
  * _end_matrix() before the arena can be used again for something else.
  */
 #define _begin_column_head(_spos, _epos, _adj, _forefronts, _n_forefronts) ({ \
-	debug("Begin column head"); \
     /* calculate sizes */ \
 	size_t next_req = _calc_next_size(_spos, _epos, _n_forefronts); \
 	/* reserve stream of memory to push onto */  \
@@ -827,7 +824,6 @@ unittest() {
  * arena can be used again.
  */
 #define _begin_column(_w, _rch, _rlen) ({ \
-    debug("Begin column"); \
 	/* push cap info */ \
 	struct dz_cap_s *cap = dz_cap(dz_mem_stream_alloc_current(dz_mem(self))); \
 	dz_mem_stream_alloc_end(dz_mem(self), sizeof(struct dz_cap_s)); \
@@ -846,7 +842,6 @@ unittest() {
 	debug("create column(%p), [%u, %u), span(%u), rrem(%ld), max(%d), inc(%d)", cap, (_w).fr.spos, (_w).fr.epos, (_w).r.epos - (_w).r.spos, (_rlen), (_w).max, (_w).inc); \
 	/* start array slice allocation */ \
 	struct dz_swgv_s *slice_data = dz_swgv(dz_mem_stream_alloc_begin(dz_mem(self), _calc_max_slice_size((_w).fr.spos, (_w).fr.epos))); \
-    debug("Column begun"); \
 	/* return array pointer */ \
 	slice_data - (_w).fr.spos; \
 })
@@ -863,7 +858,6 @@ unittest() {
  * _end_matrix().
  */
 #define _end_column(_p, _spos, _epos) ({ \
-    debug("End column"); \
 	/* finish the slice data allocation with what was actually used */ \
 	dz_mem_stream_alloc_end(dz_mem(self), ((_epos) - (_spos)) * sizeof(struct dz_swgv_s)); \
 	/* immediately next in memory, allocate up to a forefront, as a range */ \

--- a/dozeu.h
+++ b/dozeu.h
@@ -106,6 +106,11 @@ enum dz_alphabet {
 #  ifndef DZ_MAT_SIZE
 #    define DZ_MAT_SIZE				( 32 )
 #  endif
+#ifdef DZ_FULL_LENGTH_BONUS
+#define dz_end_bonus(_self, _query, _i)            ((_i) / 8 == (_query)->blen - 1 ? (_query)->bonus[8 + ((_i) & 7)] : 0)
+#else
+#define dz_end_bonus(_self, _query, _i)            0;
+#endif
 #define dz_pair_score(_self, _q, _r, _i)	( (int8_t)((_q)->arr[(_r) * (_q)->blen * L + (_i)]) + dz_end_bonus(_self, _q, _i))
 #define dz_pair_eq(_self, _q, _r, _i)		( (uint32_t)((_q)->q[(_i) - 1] & 0x1f) == (uint32_t)(_r) )
 #endif
@@ -216,8 +221,15 @@ struct dz_forefront_s {
 	struct dz_query_s const *query;
 	struct dz_cap_s const *mcap;
 };
-// When initializing forefronts, we want to be able to fill in the pad without saying 0s everywhere.
+/*
+ * When initializing forefronts, we want to be able to fill in the pad without saying 0s everywhere.
+ */
 #define DZ_FOREFRONT_PAD {0, 0, 0, 0, 0, 0, 0, 0}
+
+/*
+ * This holds the forefront for the alignment root, and the x-drop threshold,
+ * computed from the max gap length.
+ */
 struct dz_alignment_init_s {
     struct dz_forefront_s const *root;
     uint16_t xt;

--- a/dozeu.h
+++ b/dozeu.h
@@ -648,7 +648,8 @@ unittest() {
 	(struct dz_swgv_s *)(cap + 1) - (_spos); \
 })
 /*
- * Fill in a terminating cap for the most recent column passed to _end_column.
+ * Fill in a terminating cap for the most recent column passed to _end_column,
+ * using the range information already above the allocator stack.
  * Either immediately after it or in a new contiguous run of memory, reserve
  * space for a new column. If the new column is not immediately after the old
  * column, copy a (fake?) version of the old column's cap to be before it.
@@ -679,15 +680,15 @@ unittest() {
 })
 /*
  * Given the slice array address for a column begun with _begin_column() or
- * _begin_column_head(), finish the column, and allow the allocator to be used
- * again.
+ * _begin_column_head(), finish the column.
  *
  * Note that we have actually used the _spos to _epos part of the column's
  * vector, and save range data after that vector recording the range its slice
  * covers.
  *
  * Returns the address of the filled-in range, which it leaves just above the
- * allocator stack.
+ * allocator stack, to be made into a cap by _begin_column() or into a
+ * forefront by _end_matrix().
  */
 #define _end_column(_p, _spos, _epos) ({ \
 	/* write back the stack pointer and return a cap */ \

--- a/dozeu.h
+++ b/dozeu.h
@@ -1301,9 +1301,6 @@ void dz_trim(
 	struct dz_s *self,
     size_t max_bytes)
 {
-    fprintf(stderr, "Stack before trim:\n");
-    dz_mem_log_stack(dz_mem(self));
-
     struct dz_mem_block_s *keep_block = &(dz_mem(self)->blk);
     size_t bytes_found = 0;
     while (keep_block != NULL) {
@@ -1321,8 +1318,7 @@ void dz_trim(
         keep_block = keep_block->next;
     }
 
-    fprintf(stderr, "Stack after trim:\n");
-    dz_mem_log_stack(dz_mem(self));
+    return;
 }
 #endif // DZ_INCLUDE_ONCE
                               
@@ -1334,9 +1330,6 @@ void dz_flush(
 #endif
 	struct dz_s *self)
 {
-    fprintf(stderr, "Stack before flush:\n");
-    dz_mem_log_stack(dz_mem(self));
-
     // point the mem back at the initial block
 	dz_mem_flush(dz_mem(self));
     
@@ -1373,9 +1366,6 @@ void dz_flush(
         // We didn't get the right stack top at the end of all that.
         dz_error("Could not recreate post-init state when flushing! Stack top should be %p but is actually %p!", dz_mem(self)->stack.dz_flush_top, dz_mem(self)->stack.top);
     }
-
-    fprintf(stderr, "Stack after flush:\n");
-    dz_mem_log_stack(dz_mem(self));
 
 	return;
 }

--- a/example.2bit.c
+++ b/example.2bit.c
@@ -36,6 +36,7 @@ int main(int argc, char *argv[])
 	/* init score matrix and memory arena */
 	int8_t const M = 2, X = -3, GI = 5, GE = 1;		/* match, mismatch, gap open, and gap extend; g(k) = GI + k + GE for k-length gap */
 	int8_t const xdrop_threshold = 70, full_length_bonus = 10;
+	int8_t max_gap_length = (xdrop_threshold - GI) / GE;
 	int8_t const score_matrix[16] = {
 	/*                 ref-side  */
 	/*                A  C  G  T */
@@ -47,17 +48,18 @@ int main(int argc, char *argv[])
 	};
 	struct dz_s *dz = dz_init(
 		score_matrix,
-		GI, GE,
-		xdrop_threshold,
-		full_length_bonus
+		GI, GE
 	);
+	/* Initialize root of alignment */
+	struct dz_alignment_init_s aln_init = dz_align_init(dz, max_gap_length);
 
 	/* pack query */
 	char const *query = "\x0\x1\x0\x1\x3\x3\x1\x3\x0\x2\x0\x1\x3\x3\x3\x0\x1\x1\x0\x1\x3\x0";
 	struct dz_query_s const *q = dz_pack_query_forward(
-	    dz,
-	    query,						/* char const *seq: query sequence */
-	    22							/* length */
+		dz,
+		query,						/* char const *seq: query sequence */
+		full_length_bonus,
+		22							/* length */
 	);
 
 	/* init node array */
@@ -65,25 +67,26 @@ int main(int argc, char *argv[])
 
 	/* fill root: node 0 */
 	ff[0] = dz_extend(
-	    dz, q,
-	    dz_root(dz), 1,				/* struct dz_forefront_s const *ff[], uint64_t n_ffs; incoming forefront and degree; dz_root(dz) for root node */
-	    "\x0\x1\x0\x1", 4, 0		/* reference-side sequence, its length, and node id */
+		dz, q,
+		&aln_init.root, 1,			/* struct dz_forefront_s const *ff[], uint64_t n_ffs; incoming forefront and degree; dz_root(dz) for root node */
+		"\x0\x1\x0\x1", 4, 0,		/* reference-side sequence, its length, and node id */
+		aln_init.xt					/* x-drop threshold */
 	);
 
 	/* branching paths: 1, 2 -> 3 */
-	ff[1] = dz_extend(dz, q, &ff[0], 1, "\x3\x3\x2\x3", 4, 1);
-	ff[2] = dz_extend(dz, q, &ff[0], 1, "\x0\x3\x1\x1", 4, 2);
-	ff[3] = dz_extend(dz, q, &ff[1], 2, "\x0\x2\x0\x1", 4, 3);		/* "&ff[1], 2" indicates ff[1] and ff[2] are incoming nodes */
+	ff[1] = dz_extend(dz, q, &ff[0], 1, "\x3\x3\x2\x3", 4, 1, aln_init.xt);
+	ff[2] = dz_extend(dz, q, &ff[0], 1, "\x0\x3\x1\x1", 4, 2, aln_init.xt);
+	ff[3] = dz_extend(dz, q, &ff[1], 2, "\x0\x2\x0\x1", 4, 3, aln_init.xt);		/* "&ff[1], 2" indicates ff[1] and ff[2] are incoming nodes */
 
 	/* insertion: -, 4 -> 5 */
-	ff[4] = dz_extend(dz, q, &ff[3], 1, "\x3", 1, 4);
-	ff[5] = dz_extend(dz, q, &ff[3], 2, "\x3\x3\x1\x3\x0", 5, 5);	/* "&ff[3], 2" indicates ff[3] and ff[4] are incoming nodes */
+	ff[4] = dz_extend(dz, q, &ff[3], 1, "\x3", 1, 4, aln_init.xt);
+	ff[5] = dz_extend(dz, q, &ff[3], 2, "\x3\x3\x1\x3\x0", 5, 5, aln_init.xt);	/* "&ff[3], 2" indicates ff[3] and ff[4] are incoming nodes */
 
 	/* SNVs: 6, 7, 8 -> 9 */
-	ff[6] = dz_extend(dz, q, &ff[5], 1, "\x0", 1, 6);
-	ff[7] = dz_extend(dz, q, &ff[5], 1, "\x1", 1, 7);
-	ff[8] = dz_extend(dz, q, &ff[5], 1, "\x2", 1, 8);
-	ff[9] = dz_extend(dz, q, &ff[6], 3, "\x1\x0\x1\x2\x2", 5, 9);
+	ff[6] = dz_extend(dz, q, &ff[5], 1, "\x0", 1, 6, aln_init.xt);
+	ff[7] = dz_extend(dz, q, &ff[5], 1, "\x1", 1, 7, aln_init.xt);
+	ff[8] = dz_extend(dz, q, &ff[5], 1, "\x2", 1, 8, aln_init.xt);
+	ff[9] = dz_extend(dz, q, &ff[6], 3, "\x1\x0\x1\x2\x2", 5, 9, aln_init.xt);
 
 	/* detect max */
 	struct dz_forefront_s const *max = NULL;

--- a/example.c
+++ b/example.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #define UNITTEST				1
+#define DEBUG					1
 #define DZ_FULL_LENGTH_BONUS						/* use full-length bonus feature */
 #define DZ_CIGAR_OP				0x44493d58			/* 'D', 'I', '=', 'X'; the default is 0x04030201 */
 #include "dozeu.h"

--- a/example.c
+++ b/example.c
@@ -44,16 +44,16 @@ int main(int argc, char *argv[])
 	};
 	struct dz_s *dz = dz_init(
 		score_matrix,
-		GI, GE,
-		xdrop_threshold,
-		full_length_bonus
+		GI, GE
 	);
+    // TODO: does xdrop_threshold go in anymore?
 
 	/* pack query */
 	char const *query = "ACACTTCTAGACTTTACCACTA";
 	struct dz_query_s const *q = dz_pack_query_forward(
 	    dz,
 	    query,						/* char const *seq: query sequence */
+        full_length_bonus,
 	    strlen(query)				/* length */
 	);
 

--- a/example.c
+++ b/example.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #define UNITTEST				1
-#define DEBUG					1
 #define DZ_FULL_LENGTH_BONUS						/* use full-length bonus feature */
 #define DZ_CIGAR_OP				0x44493d58			/* 'D', 'I', '=', 'X'; the default is 0x04030201 */
 #include "dozeu.h"

--- a/example.c
+++ b/example.c
@@ -47,65 +47,72 @@ int main(int argc, char *argv[])
 		score_matrix,
 		GI, GE
 	);
-	/* Initialize root of alignment */
-	struct dz_alignment_init_s aln_init = dz_align_init(dz, max_gap_length);
 
-	/* pack query */
-	char const *query = "ACACTTCTAGACTTTACCACTA";
-	struct dz_query_s const *q = dz_pack_query_forward(
-		dz,
-		query,						/* char const *seq: query sequence */
-		full_length_bonus,
-		strlen(query)				/* length */
-	);
+    for (int repeat = 0; repeat < 3; ++repeat) {
 
-	/* init node array */
-	struct dz_forefront_s const *ff[10] = { 0 };
+        /* Initialize root of alignment */
+	    struct dz_alignment_init_s aln_init = dz_align_init(dz, max_gap_length);
 
-	/* fill root: node 0 */
-	ff[0] = dz_extend(
-		dz, q,
-		&aln_init.root, 1,			/* struct dz_forefront_s const *ff[], uint64_t n_ffs; incoming forefront and degree; */
-		"ACAC", strlen("ACAC"), 0,	/* reference-side sequence, its length, and node id */
-		aln_init.xt					/* x-drop threshold */
-	);
+        /* pack query */
+        char const *query = "ACACTTCTAGACTTTACCACTA";
+        struct dz_query_s const *q = dz_pack_query_forward(
+            dz,
+            query,						/* char const *seq: query sequence */
+            full_length_bonus,
+            strlen(query)				/* length */
+        );
 
-	/* branching paths: 1, 2 -> 3 */
-	ff[1] = dz_extend(dz, q, &ff[0], 1, "TTGT", strlen("TTGT"), 1, aln_init.xt);
-	ff[2] = dz_extend(dz, q, &ff[0], 1, "ATCC", strlen("ATCC"), 2, aln_init.xt);
-	ff[3] = dz_extend(dz, q, &ff[1], 2, "AGAC", strlen("AGAC"), 3, aln_init.xt);	/* "&ff[1], 2" indicates ff[1] and ff[2] are incoming nodes */
+        /* init node array */
+        struct dz_forefront_s const *ff[10] = { 0 };
 
-	/* insertion: -, 4 -> 5 */
-	ff[4] = dz_extend(dz, q, &ff[3], 1, "T", strlen("T"), 4, aln_init.xt);
-	ff[5] = dz_extend(dz, q, &ff[3], 2, "TTCTA", strlen("TTCTA"), 5, aln_init.xt);	/* "&ff[3], 2" indicates ff[3] and ff[4] are incoming nodes */
+        /* fill root: node 0 */
+        ff[0] = dz_extend(
+            dz, q,
+            &aln_init.root, 1,			/* struct dz_forefront_s const *ff[], uint64_t n_ffs; incoming forefront and degree; */
+            "ACAC", strlen("ACAC"), 0,	/* reference-side sequence, its length, and node id */
+            aln_init.xt					/* x-drop threshold */
+        );
 
-	/* SNVs: 6, 7, 8 -> 9 */
-	ff[6] = dz_extend(dz, q, &ff[5], 1, "A", strlen("A"), 6, aln_init.xt);
-	ff[7] = dz_extend(dz, q, &ff[5], 1, "C", strlen("C"), 7, aln_init.xt);
-	ff[8] = dz_extend(dz, q, &ff[5], 1, "G", strlen("G"), 8, aln_init.xt);
-	ff[9] = dz_extend(dz, q, &ff[6], 3, "CACGG", strlen("CACGG"), 9, aln_init.xt);
+        /* branching paths: 1, 2 -> 3 */
+        ff[1] = dz_extend(dz, q, &ff[0], 1, "TTGT", strlen("TTGT"), 1, aln_init.xt);
+        ff[2] = dz_extend(dz, q, &ff[0], 1, "ATCC", strlen("ATCC"), 2, aln_init.xt);
+        ff[3] = dz_extend(dz, q, &ff[1], 2, "AGAC", strlen("AGAC"), 3, aln_init.xt);	/* "&ff[1], 2" indicates ff[1] and ff[2] are incoming nodes */
 
-	/* detect max */
-	struct dz_forefront_s const *max = NULL;
-	for(size_t i = 0; i < 10; i++) {
-		if(max == NULL || ff[i]->max > max->max) { max = ff[i]; }
-	}
+        /* insertion: -, 4 -> 5 */
+        ff[4] = dz_extend(dz, q, &ff[3], 1, "T", strlen("T"), 4, aln_init.xt);
+        ff[5] = dz_extend(dz, q, &ff[3], 2, "TTCTA", strlen("TTCTA"), 5, aln_init.xt);	/* "&ff[3], 2" indicates ff[3] and ff[4] are incoming nodes */
 
-	/* traceback */
-	struct dz_alignment_s const *aln = dz_trace(
-		dz,
-		max
-	);
+        /* SNVs: 6, 7, 8 -> 9 */
+        ff[6] = dz_extend(dz, q, &ff[5], 1, "A", strlen("A"), 6, aln_init.xt);
+        ff[7] = dz_extend(dz, q, &ff[5], 1, "C", strlen("C"), 7, aln_init.xt);
+        ff[8] = dz_extend(dz, q, &ff[5], 1, "G", strlen("G"), 8, aln_init.xt);
+        ff[9] = dz_extend(dz, q, &ff[6], 3, "CACGG", strlen("CACGG"), 9, aln_init.xt);
 
-	printf("ref_length(%u), query_length(%u), score(%d), path(%s)\n", aln->ref_length, aln->query_length, aln->score, aln->path);
-	for(size_t i = 0; i < aln->span_length; i++) {
-		struct dz_path_span_s const *s = &aln->span[i];
-		printf("node_id(%u), subpath_length(%u), subpath(%.*s)\n",
-			s->id,
-			s[1].offset - s[0].offset,
-			s[1].offset - s[0].offset, &aln->path[s->offset]
-		);
-	}
+        /* detect max */
+        struct dz_forefront_s const *max = NULL;
+        for(size_t i = 0; i < 10; i++) {
+            if(max == NULL || ff[i]->max > max->max) { max = ff[i]; }
+        }
+
+        /* traceback */
+        struct dz_alignment_s const *aln = dz_trace(
+            dz,
+            max
+        );
+
+        printf("ref_length(%u), query_length(%u), score(%d), path(%s)\n", aln->ref_length, aln->query_length, aln->score, aln->path);
+        for(size_t i = 0; i < aln->span_length; i++) {
+            struct dz_path_span_s const *s = &aln->span[i];
+            printf("node_id(%u), subpath_length(%u), subpath(%.*s)\n",
+                s->id,
+                s[1].offset - s[0].offset,
+                s[1].offset - s[0].offset, &aln->path[s->offset]
+            );
+        }
+
+        /* clean up for re-use */
+        dz_flush(dz);
+    }
 
 	/* clean up */
 	dz_destroy(dz);

--- a/example.c
+++ b/example.c
@@ -34,6 +34,7 @@ int main(int argc, char *argv[])
 	/* init score matrix and memory arena */
 	int8_t const M = 2, X = -3, GI = 5, GE = 1;		/* match, mismatch, gap open, and gap extend; g(k) = GI + k + GE for k-length gap */
 	int8_t const xdrop_threshold = 70, full_length_bonus = 10;
+	int8_t max_gap_length = (xdrop_threshold - GI) / GE;
 	int8_t const score_matrix[16] = {
 	/*              ref-side  */
 	/*             A  C  G  T */
@@ -46,15 +47,16 @@ int main(int argc, char *argv[])
 		score_matrix,
 		GI, GE
 	);
-    // TODO: does xdrop_threshold go in anymore?
+	/* Initialize root of alignment */
+	struct dz_alignment_init_s aln_init = dz_align_init(dz, max_gap_length);
 
 	/* pack query */
 	char const *query = "ACACTTCTAGACTTTACCACTA";
 	struct dz_query_s const *q = dz_pack_query_forward(
-	    dz,
-	    query,						/* char const *seq: query sequence */
-        full_length_bonus,
-	    strlen(query)				/* length */
+		dz,
+		query,						/* char const *seq: query sequence */
+		full_length_bonus,
+		strlen(query)				/* length */
 	);
 
 	/* init node array */
@@ -62,25 +64,26 @@ int main(int argc, char *argv[])
 
 	/* fill root: node 0 */
 	ff[0] = dz_extend(
-	    dz, q,
-	    dz_root(dz), 1,				/* struct dz_forefront_s const *ff[], uint64_t n_ffs; incoming forefront and degree; dz_root(dz) for root node */
-	    "ACAC", strlen("ACAC"), 0	/* reference-side sequence, its length, and node id */
+		dz, q,
+		&aln_init.root, 1,			/* struct dz_forefront_s const *ff[], uint64_t n_ffs; incoming forefront and degree; */
+		"ACAC", strlen("ACAC"), 0,	/* reference-side sequence, its length, and node id */
+		aln_init.xt					/* x-drop threshold */
 	);
 
 	/* branching paths: 1, 2 -> 3 */
-	ff[1] = dz_extend(dz, q, &ff[0], 1, "TTGT", strlen("TTGT"), 1);
-	ff[2] = dz_extend(dz, q, &ff[0], 1, "ATCC", strlen("ATCC"), 2);
-	ff[3] = dz_extend(dz, q, &ff[1], 2, "AGAC", strlen("AGAC"), 3);		/* "&ff[1], 2" indicates ff[1] and ff[2] are incoming nodes */
+	ff[1] = dz_extend(dz, q, &ff[0], 1, "TTGT", strlen("TTGT"), 1, aln_init.xt);
+	ff[2] = dz_extend(dz, q, &ff[0], 1, "ATCC", strlen("ATCC"), 2, aln_init.xt);
+	ff[3] = dz_extend(dz, q, &ff[1], 2, "AGAC", strlen("AGAC"), 3, aln_init.xt);	/* "&ff[1], 2" indicates ff[1] and ff[2] are incoming nodes */
 
 	/* insertion: -, 4 -> 5 */
-	ff[4] = dz_extend(dz, q, &ff[3], 1, "T", strlen("T"), 4);
-	ff[5] = dz_extend(dz, q, &ff[3], 2, "TTCTA", strlen("TTCTA"), 5);	/* "&ff[3], 2" indicates ff[3] and ff[4] are incoming nodes */
+	ff[4] = dz_extend(dz, q, &ff[3], 1, "T", strlen("T"), 4, aln_init.xt);
+	ff[5] = dz_extend(dz, q, &ff[3], 2, "TTCTA", strlen("TTCTA"), 5, aln_init.xt);	/* "&ff[3], 2" indicates ff[3] and ff[4] are incoming nodes */
 
 	/* SNVs: 6, 7, 8 -> 9 */
-	ff[6] = dz_extend(dz, q, &ff[5], 1, "A", strlen("A"), 6);
-	ff[7] = dz_extend(dz, q, &ff[5], 1, "C", strlen("C"), 7);
-	ff[8] = dz_extend(dz, q, &ff[5], 1, "G", strlen("G"), 8);
-	ff[9] = dz_extend(dz, q, &ff[6], 3, "CACGG", strlen("CACGG"), 9);
+	ff[6] = dz_extend(dz, q, &ff[5], 1, "A", strlen("A"), 6, aln_init.xt);
+	ff[7] = dz_extend(dz, q, &ff[5], 1, "C", strlen("C"), 7, aln_init.xt);
+	ff[8] = dz_extend(dz, q, &ff[5], 1, "G", strlen("G"), 8, aln_init.xt);
+	ff[9] = dz_extend(dz, q, &ff[6], 3, "CACGG", strlen("CACGG"), 9, aln_init.xt);
 
 	/* detect max */
 	struct dz_forefront_s const *max = NULL;


### PR DESCRIPTION
This removes some arrays of `:` bytes that were overflowing onto the stack. It also adds a mode to the allocator where it can track running variable-length allocations, and uses it for doing allocations so that allocations are actually checked.

I had to make these changes to enable aligning multi-kilobase tails of HiFi reads.